### PR TITLE
Making compatible with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+import sys
+
+requires = ['requests>=0.10.8']
+
+setup(
+    name = "closeio_api",
+    py_modules = ['closeio_api'],
+    version = "0.1",
+    description = "Closeio Python library",
+    author = "Closeio Team",
+    url = "https://github.com/elasticsales/closeio-api/",
+    install_requires = requires,
+    classifiers = [
+        "Programming Language :: Python",
+        "Operating System :: OS Independent",
+        ],
+    long_description = """\
+        Closeio Python library
+         """ )


### PR DESCRIPTION
With setup.py in place, the library can be installed with - 

`pip install -e git+git@github.com:elasticsales/closeio-api.git#egg=closeio_api`
