### PR TITLE
Updates setup.py so that `python setup.py build` works correctly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ requires = ['requests>=0.10.8']
 
 setup(
     name = "closeio_api",
-    py_modules = ['closeio_api'],
+    packages = ['closeio_api'],
     version = "0.1",
     description = "Closeio Python library",
     author = "Closeio Team",


### PR DESCRIPTION
This removes the need to pip install with `-e` as referred to in issue #1. It will also allow the library to be used in a `requirements.txt` file.
