### PR TITLE
Fix delete secondary addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Unidecode==0.04.11
 blist==1.3.4
 click==3.3
 python-dateutil==2.1
+fake-factory==0.5.3

--- a/scripts/delete_secondary_addresses.py
+++ b/scripts/delete_secondary_addresses.py
@@ -6,51 +6,55 @@ import logging
 
 from closeio_api import Client as CloseIO_API, APIError
 
-parser = argparse.ArgumentParser(description='Delete all but first address for leads with multiple addresses.')
-parser.add_argument('--api-key', '-k', required=True, help='')
-parser.add_argument('--confirmed', '-c', action='store_true',
-                    help='Without this flag, the script will do a dry run without actually updating any data.')
-parser.add_argument('--development', '-d', action='store_true',
-                    help='Use a development (testing) server rather than production.')
-args = parser.parse_args()
 
-log_format = "[%(asctime)s] %(levelname)s %(message)s"
-if not args.confirmed:
-    log_format = 'DRY RUN: '+log_format
-logging.basicConfig(level=logging.INFO, format=log_format)
-logging.debug('parameters: %s' % vars(args))
+def run(api_key, development, confirmed, limit=100):
+    log_format = "[%(asctime)s] %(levelname)s %(message)s"
+    if not confirmed:
+        log_format = 'DRY RUN: '+log_format
+    logging.basicConfig(level=logging.INFO, format=log_format)
 
+    api = CloseIO_API(api_key, development=development)
 
-api = CloseIO_API(args.api_key, development=args.development)
+    # loop through existing leads with multiple addresses
 
-# loop through existing leads with multiple addresses
+    LEADS_QUERY_WITH_MULTIPLE_ADDRESSES = "addresses > 1 sort:created"
+    has_more = True
+    offset = 0
 
-LEADS_QUERY_WITH_MULTIPLE_ADDRESSES = "addresses > 1 sort:created"
-has_more = True
-offset = 0
+    operations_queue = []
 
-operations_queue = []
-
-while has_more:
-    resp = api.get('lead', data={
-        'query': LEADS_QUERY_WITH_MULTIPLE_ADDRESSES,
-        '_skip': offset,
-        '_fields': 'id,addresses'
-    })
-
-    leads = resp['data']
-
-    for lead in leads:
-        operations_queue.append({
-            'url': 'lead/' + lead['id'],
-            'data': {'addresses': lead['addresses'][:1]},
-            'log': 'removed %d extra address(es) for %s' % (len(lead['addresses'][1:]), lead['id']),
+    while has_more:
+        resp = api.get('lead', data={
+            'query': LEADS_QUERY_WITH_MULTIPLE_ADDRESSES,
+            '_skip': offset,
+            '_fields': 'id,addresses'
         })
 
-    offset += len(leads)
-    has_more = resp['has_more']
+        leads = resp['data']
 
-for operation in operations_queue:
-    if args.confirmed:
-        api.put(operation['url'], data=operation['data'])
-    logging.info(operation['log'])
+        for lead in leads:
+            operations_queue.append({
+                'url': 'lead/' + lead['id'],
+                'data': {'addresses': lead['addresses'][:1]},
+                'log': 'removed %d extra address(es) for %s' % (len(lead['addresses'][1:]), lead['id']),
+            })
+
+        offset += len(leads)
+        has_more = resp['has_more']
+
+    for operation in operations_queue:
+        if confirmed:
+            api.put(operation['url'], data=operation['data'])
+        logging.info(operation['log'])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Delete all but first address for leads with multiple addresses.')
+    parser.add_argument('--api-key', '-k', required=True, help='')
+    parser.add_argument('--confirmed', '-c', action='store_true',
+                        help='Without this flag, the script will do a dry run without actually updating any data.')
+    parser.add_argument('--development', '-d', action='store_true',
+                        help='Use a development (testing) server rather than production.')
+    args = parser.parse_args()
+    logging.debug('parameters: %s' % vars(args))
+    run(api_key=args.api_key, development=args.development, confirmed=args.confirmed)

--- a/scripts/delete_secondary_addresses.py
+++ b/scripts/delete_secondary_addresses.py
@@ -36,7 +36,7 @@ def run(api_key, development, confirmed, limit=100):
             operations_queue.append({
                 'url': 'lead/' + lead['id'],
                 'data': {'addresses': lead['addresses'][:1]},
-                'log': 'removed %d extra address(es) for %s' % (len(lead['addresses'][1:]), lead['id']),
+                'log': 'removed %d extra address(es) for %s: %s' % (len(lead['addresses'][1:]), lead['id'], lead['addresses'][:1]),
             })
 
         offset += len(leads)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# Running tests
+
+To run a single test run the command below from the project root:
+
+`CLOSEIO_API_KEY=<your api key> PYTHONPATH=.:$PYTHONPATH python tests/<test file_name>.py`

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+from faker import Factory
+
+
+fake = Factory.create()
+logging.basicConfig(level=logging.INFO)
+
+
+class Factory(object):
+    """docstring for Factory"""
+    def __init__(self, api):
+        self.api = api
+
+    def delete_all_leads(self):
+        has_more = True
+
+        lead_ids = []
+        while has_more:
+            resp = self.api.get('lead', data={
+                'query': '*',
+                '_fields': 'id'
+            })
+
+            leads = resp['data']
+
+            for lead in leads:
+                lead_ids.append(lead['id'])
+
+            has_more = resp['has_more']
+
+        for lead_id in lead_ids:
+            self.api.delete('lead/' + lead_id)
+            logging.info("deleted lead %s", lead_id)
+        logging.info("deleted all leads")
+
+    def lead_with_addresses(self, addresses_count=1):
+        name = fake.company()
+        lead = {
+            "display_name": name,
+            "addresses": [],
+            "name": name,
+            "contacts": [],
+            "custom": {},
+            "url": None,
+            "description": fake.catch_phrase(),
+        }
+        for i in range(addresses_count):
+            address = {
+                "label": "business",
+                "address_1": fake.street_address(),
+                "address_2": fake.secondary_address(),
+                "city": fake.city(),
+                "state": fake.state_abbr(),
+                "zipcode": fake.zipcode(),
+                "country": fake.country_code(),
+            }
+            lead['addresses'].append(address)
+
+        self.api.post('lead', data=lead)
+        logging.info("created lead %s", lead)
+
+

--- a/tests/test_delete_secondary_addresses.py
+++ b/tests/test_delete_secondary_addresses.py
@@ -32,7 +32,7 @@ class TestDeleteSecondaryAddresses(unittest.TestCase):
 
         time.sleep(1.5)
 
-        leads = list(utils.all(self.api))
+        leads = list(utils.all(self.api, fields="id,addresses"))
         self.assertEqual(9, len(leads))
         for lead in leads:
             self.assertEqual(1, len(lead['addresses']), "lead %s has too many addresses" % lead)

--- a/tests/test_delete_secondary_addresses.py
+++ b/tests/test_delete_secondary_addresses.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import unittest
+import os
+import time
+
+from closeio_api import Client as CloseIO_API, APIError
+from scripts import delete_secondary_addresses
+from factories import Factory
+import utils
+
+api_key = os.getenv("CLOSEIO_API_KEY")
+
+
+class TestDeleteSecondaryAddresses(unittest.TestCase):
+    def setUp(self):
+        self.api = CloseIO_API(api_key)
+        self.factory = Factory(self.api)
+        self.factory.delete_all_leads()
+
+    def test_run(self):
+        for i in range(3):
+            self.factory.lead_with_addresses(1)
+        for i in range(6):
+            self.factory.lead_with_addresses(2)
+
+        time.sleep(1.5)
+
+        delete_secondary_addresses.run(api_key=api_key, development=False, confirmed=True, limit=3)
+
+        time.sleep(1.5)
+
+        leads = list(utils.all(self.api))
+        self.assertEqual(9, len(leads))
+        for lead in leads:
+            self.assertEqual(1, len(lead['addresses']), "lead %s has too many addresses" % lead)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_delete_secondary_addresses.py
+++ b/tests/test_delete_secondary_addresses.py
@@ -23,8 +23,10 @@ class TestDeleteSecondaryAddresses(unittest.TestCase):
     def test_run(self):
         for i in range(3):
             self.factory.lead_with_addresses(1)
-        for i in range(6):
+        for i in range(3):
             self.factory.lead_with_addresses(2)
+        for i in range(3):
+            self.factory.lead_with_addresses(3)
 
         time.sleep(1.5)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def all(api, query='*'):
+    has_more = True
+
+    while has_more:
+        resp = api.get('lead', data={
+            'query': query,
+            '_fields': 'id,addresses'
+        })
+
+        leads = resp['data']
+
+        for lead in leads:
+            yield lead
+
+        has_more = resp['has_more']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 
-def all(api, query='*'):
+def all(api, query='*', fields='id'):
     has_more = True
 
     while has_more:
         resp = api.get('lead', data={
             'query': query,
-            '_fields': 'id,addresses'
+            '_fields': fields,
         })
 
         leads = resp['data']


### PR DESCRIPTION
Implements feedback from from https://github.com/closeio/closeio-api/pull/46#issuecomment-150830246

Some things to notice:

* I've added some extra logging when deleting addresses (I couldn't spot where you added the logging)
* to fix the flaw while paginating the search results, I've split the logic in a loop that collects the operations to run and one more to actually run the requests. I wanted to experiment a different way from the one you've indicated but I am happy to switch to the "always scan the first page + sleep(1.5)" approach if you see any shortcomings on my approach!
* I've introduced a test to avoid manual tests my solutions. I'm hoping this will come useful to partially automate testing for the other project I'll be working on.

/cc @philfreo 