### PR TITLE
Fix inconsistent behaviour for delete_secondary_addresses

### DIFF
--- a/scripts/delete_secondary_addresses.py
+++ b/scripts/delete_secondary_addresses.py
@@ -3,45 +3,51 @@
 
 import argparse
 import logging
+import time
 
 from closeio_api import Client as CloseIO_API, APIError
 
-parser = argparse.ArgumentParser(description='Delete all but first address for leads with multiple addresses.')
-parser.add_argument('--api-key', '-k', required=True, help='')
-parser.add_argument('--confirmed', '-c', action='store_true',
-                    help='Without this flag, the script will do a dry run without actually updating any data.')
-parser.add_argument('--development', '-d', action='store_true',
-                    help='Use a development (testing) server rather than production.')
-args = parser.parse_args()
 
-log_format = "[%(asctime)s] %(levelname)s %(message)s"
-if not args.confirmed:
-    log_format = 'DRY RUN: '+log_format
-logging.basicConfig(level=logging.INFO, format=log_format)
-logging.debug('parameters: %s' % vars(args))
+def run(api_key, development, confirmed, limit=100):
+    api = CloseIO_API(api_key, development=development)
+
+    # loop through existing leads with multiple addresses
+
+    LEADS_QUERY_WITH_MULTIPLE_ADDRESSES = "addresses > 1 sort:created"
+    has_more = True
+
+    while has_more:
+        resp = api.get('lead', data={
+            'query': LEADS_QUERY_WITH_MULTIPLE_ADDRESSES,
+            '_fields': 'id,addresses',
+            '_limit': limit,
+        })
+
+        leads = resp['data']
+
+        for lead in leads:
+            if confirmed:
+                api.put('lead/' + lead['id'], data={'addresses': lead['addresses'][:1]})
+            logging.info('removed %d extra address(es) for %s' % (len(lead['addresses'][1:]), lead['id']))
+
+        has_more = resp['has_more']
+
+        time.sleep(1.5)  # give the search indexer some time to catch up with the changes
 
 
-api = CloseIO_API(args.api_key, development=args.development)
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Delete all but first address for leads with multiple addresses.')
+    parser.add_argument('--api-key', '-k', required=True, help='')
+    parser.add_argument('--confirmed', '-c', action='store_true',
+                        help='Without this flag, the script will do a dry run without actually updating any data.')
+    parser.add_argument('--development', '-d', action='store_true',
+                        help='Use a development (testing) server rather than production.')
+    args = parser.parse_args()
 
-# loop through existing leads with multiple addresses
+    log_format = "[%(asctime)s] %(levelname)s %(message)s"
+    if not args.confirmed:
+        log_format = 'DRY RUN: ' + log_format
+    logging.basicConfig(level=logging.INFO, format=log_format)
+    logging.debug('parameters: %s' % vars(args))
 
-LEADS_QUERY_WITH_MULTIPLE_ADDRESSES = "addresses > 1 sort:created"
-has_more = True
-offset = 0
-
-while has_more:
-    resp = api.get('lead', data={
-        'query': LEADS_QUERY_WITH_MULTIPLE_ADDRESSES,
-        '_skip': offset,
-        '_fields': 'id,addresses'
-    })
-
-    leads = resp['data']
-
-    for lead in leads:
-        if args.confirmed:
-            api.put('lead/' + lead['id'], data={'addresses': lead['addresses'][:1]})
-        logging.info('removed %d extra address(es) for %s' % (len(lead['addresses'][1:]), lead['id']))
-
-    offset += len(leads)
-    has_more = resp['has_more']
+    run(api_key=args.api_key, development=args.development, confirmed=args.confirmed)


### PR DESCRIPTION
The previous implementation was paginating through search results and changing
them at the same time (see https://github.com/closeio/closeio-api/pull/46#issuecomment-150830246).

This causes inconsistent results depending on how fast the search indexer catches up with the changes.

Imagine there are 3 pages of results initially, by the time you're moving onto page 2 you're actually hitting the initial page 3 and skipping the initial page 2 of data, since the original page 2 becomes page 1 after the modifications.

The fix involves looping through the first search results page, update all leads so they don't have any more secondary addresses, sleep for 1.5 to let the indexer catch up and reload the first page. The leads that were updated won't match the search query any more so the first page will contain new leads to be cleaned up.

Supersedes #47 .
