### PR TITLE
Issue57. Default X-TZ-Offset encoding

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -35,7 +35,7 @@ class API(object):
             '----------- /HTTP Request -----------'))
 
     def dispatch(self, method_name, endpoint, data=None, **kwargs):
-        for retry_count in xrange(self.max_retries):
+        for retry_count in range(self.max_retries):
             try:
                 request = requests.Request(
                     method_name,

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -13,7 +13,7 @@ class API(object):
         self.base_url = base_url
         self.async = async
         self.max_retries = max_retries
-        self.tz_offset = tz_offset or local_tz_offset()
+        self.tz_offset = tz_offset or str(local_tz_offset())
 
         if async:
             import grequests

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ setup(
     install_requires = requires,
     classifiers = [
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Operating System :: OS Independent",
         ],
     long_description = """\


### PR DESCRIPTION
From what I've seen the problem is not just the `X-TZ-Offset` header, but that the library is not written in python 3, but in python 2. It's too bad that that wasn't announced clearly in `setup.py`.

Anyway, I've made a couple of fixes that make the library work in python3 for what I was doing which is just creating a lead.

Fixes #57