### PR TITLE
APIError message should contain the response's status code

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -13,9 +13,8 @@ class APIError(Exception):
     """Raised when sending a request to the API failed."""
 
     def __init__(self, response):
-        # For compatibility purposes we can access the original string through
-        # the args property.
-        super(APIError, self).__init__(response.text)
+        message = u'({}) {}'.format(response.status_code, response.text)
+        super(APIError, self).__init__(message)
         self.response = response
 
 


### PR DESCRIPTION
So that it's obvious at a glance what kind of an error we experienced. Right now it's possible to get an enigmatic traceback:
```
In [3]: api.get('me')
Traceback (most recent call last)
<ipython-input-3-842652bd220e> in <module>()
----> 1 api.get('me')

/Users/wojcikstefan/Repos/closeio-api/closeio_api/__init__.py in get(self, endpoint, params, **kwargs)
    132         """
    133         kwargs.update({'params': params})
--> 134         return self._dispatch('get', endpoint+'/', **kwargs)
    135
    136     def post(self, endpoint, data, **kwargs):

/Users/wojcikstefan/Repos/closeio-api/closeio_api/__init__.py in _dispatch(self, method_name, endpoint, api_key, data, debug, **kwargs)
    108             raise ValidationError(response)
    109         else:
--> 110             raise APIError(response)
    111
    112     def _get_rate_limit_sleep_time(self, response):

APIError:
```