### PR TITLE
make sure TZ-Offset is an str

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -48,7 +48,7 @@ class API(object):
 
         self.session.headers.update({
             'Content-Type': 'application/json',
-            'X-TZ-Offset': self.tz_offset
+            'X-TZ-Offset': str(self.tz_offset)
         })
 
     def _prepare_request(self, method_name, endpoint, api_key=None, data=None,


### PR DESCRIPTION
There appears to be an issue with some versions of the requests library where we need to wrap tz_offset in a string. 

More info on this here: https://github.com/requests/requests/issues/4333

The error some customers are getting is:
```
 File "/Library/Python/2.7/site-packages/closeio_api/__init__.py", line 56, in get
    return self.dispatch('get', endpoint)
  File "/Library/Python/2.7/site-packages/closeio_api/__init__.py", line 34, in dispatch
    headers={'Content-Type': 'application/json', 'X-TZ-Offset': self.tz_offset}
  File "/Library/Python/2.7/site-packages/requests/sessions.py", line 521, in get
    return self.request('GET', url, **kwargs)
  File "/Library/Python/2.7/site-packages/requests/sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "/Library/Python/2.7/site-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/Library/Python/2.7/site-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/Library/Python/2.7/site-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/Library/Python/2.7/site-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
requests.exceptions.InvalidHeader: Value for header {X-TZ-Offset: -8} must be of type str or bytes, not <type 'int'>
```