### PR TITLE
Remove unused urllib from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A convenient Python wrapper for the [Close.io](https://close.io/) API.
 
 ```python
 from closeio_api import Client
-import urllib
 
 api = Client('YOUR_API_KEY')
 


### PR DESCRIPTION
The example on the homepage imports urllib but doesn't use it. This removes it to avoid confusing users into thinking they'll need ot handle their own network calls.