### PR TITLE
Only send Content-Type header if data exists

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -47,7 +47,6 @@ class API(object):
             self.session.auth = (api_key, '')
 
         self.session.headers.update({
-            'Content-Type': 'application/json',
             'X-TZ-Offset': self.tz_offset
         })
 
@@ -61,6 +60,13 @@ class API(object):
         else:
             auth = None
             assert self.session.auth, 'Must specify api_key.'
+
+        if data and not 'Content-Type' in self.session.headers:
+            self.session.headers.update({
+                'Content-Type': 'application/json'
+            })
+        elif not data and 'Content-Type' in self.session.headers:
+            del self.session.headers['Content-Type']
 
         kwargs.update({
             'auth': auth,

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -61,15 +61,15 @@ class API(object):
             auth = None
             assert self.session.auth, 'Must specify api_key.'
 
-        if data and not 'Content-Type' in self.session.headers:
-            self.session.headers.update({
+        headers = kwargs.pop('headers', {})
+        if data:
+            headers.update({
                 'Content-Type': 'application/json'
             })
-        elif not data and 'Content-Type' in self.session.headers:
-            del self.session.headers['Content-Type']
 
         kwargs.update({
             'auth': auth,
+            'headers': headers,
             'json': data
         })
         request = requests.Request(method_name, self.base_url + endpoint,


### PR DESCRIPTION
Closes #92 

This PR makes it so that we don't add in the `Content-Type` header by default when initializing the API Client, but adds conditionals to `_prepare_request` so that:

- if the request `data` field exists but the `Content-Type` header does not exist in `self.session.headers`, add it in so it will be sent with the request. 

- If the `data` field does not exist, but the `Content-Type` header is in `self.session.headers`, remove it so it won't be sent with the request. 