### PR TITLE
Add custom User Agent to every request, and expose the version in a readable way

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -5,9 +5,11 @@ import requests
 
 from closeio_api.utils import local_tz_offset
 
-
 DEFAULT_RATE_LIMIT_DELAY = 2   # Seconds
 
+# To update the package version, change this variable. This variable is also
+# read by setup.py when installing the package. 
+__version__ = '1.2'
 
 class APIError(Exception):
     """Raised when sending a request to the API failed."""
@@ -47,6 +49,10 @@ class API(object):
             self.session.auth = (api_key, '')
 
         self.session.headers.update({
+            'User-Agent': 'python closeio v{} {}'.format(
+                __version__,
+                requests.utils.default_user_agent()
+            ),
             'X-TZ-Offset': self.tz_offset
         })
 

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -49,7 +49,7 @@ class API(object):
             self.session.auth = (api_key, '')
 
         self.session.headers.update({
-            'User-Agent': 'python closeio v{} {}'.format(
+            'User-Agent': 'Close/{} python ({})'.format(
                 __version__,
                 requests.utils.default_user_agent()
             ),

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
+import io
+import re
 from setuptools import setup
+
+VERSION_FILE = "closeio_api/__init__.py"
+with io.open(VERSION_FILE, "rt", encoding="utf8") as f:
+    version = re.search(r'__version__ = ([\'"])(.*?)\1', f.read()).group(2)
 
 setup(
     name="closeio",
     packages=['closeio_api'],
-    version="1.1",
+    version=version,
     description="Close API Python Client",
     long_description="Close API Python Client",
     author="Close Team",


### PR DESCRIPTION
Closes #80 

This PR:

- Changes the user agent sent on requests from `python-requests/X` to `python closeio vY python-requests/X`, where Y is the version of the `closeio-api` wrapper and `X` is the python-requests version
- Adds a `__version__` variable to `__init__.py` to keep track of the version.
- Adds a helper to setup.py to read the `__version__` variable from `__init__.py` to keep things consistent when installing the package. 
- Updates the version from `1.1` to `1.2`

I used the same structure as the [Cleancat](https://github.com/closeio/cleancat/blob/master/setup.py) repo to do this.