### PR TITLE
Add retries for addtional response codes

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -115,13 +115,13 @@ class API(object):
                 
                 # Retry 503 errors or 502 or 504 erors on GET requests. 
                 elif response.status_code == 503 or (
-                    method_name == "get" and response.status_code in (502, 504)
+                    method_name == 'get' and response.status_code in (502, 504)
                 ):
                     sleep_time = self._get_randomized_sleep_time_for_error(
                         response.status_code, retry_count
                     )
                     logging.debug(
-                        "Request hit a {}, sleeping for {} seconds".format(
+                        'Request hit a {}, sleeping for {} seconds'.format(
                             response.status_code, sleep_time
                         )
                     )


### PR DESCRIPTION
This PR adds retries for `503` status codes and `502` and `504` status codes on `GET` requests. 

In terms of intervals for retries, for 503s, each retry we chose a random number between 2 - 4 seconds. 

For 502 or 504 GETs, we choose a random integer between 60 and 90 seconds and multiply that by the number of current retries. 

I also bumped up the version number to `1.3` even though we never actually released `1.2` to PyPI. 