### PR TITLE
Fix responses with 204 status codes

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -11,7 +11,7 @@ DEFAULT_RATE_LIMIT_DELAY = 2   # Seconds
 
 # To update the package version, change this variable. This variable is also
 # read by setup.py when installing the package. 
-__version__ = '1.3'
+__version__ = '1.4'
 
 class APIError(Exception):
     """Raised when sending a request to the API failed."""

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -132,6 +132,9 @@ class API(object):
                 break
 
         if response.ok:
+            # 204 responses have no content. 
+            if response.status_code == 204:
+                return ''
             return response.json()
         elif response.status_code == 400:
             raise ValidationError(response)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,3 +163,13 @@ def test_validation_error(api_client):
     err = excinfo.value
     assert err.errors == []
     assert err.field_errors['lead'] == 'This field is required.'
+
+@responses.activate
+def test_204_responses(api_client):
+    responses.add(
+        responses.DELETE,
+        "https://api.close.com/api/v1/pipeline/pipe_1234/",
+        status=204
+    )
+    resp = api_client.delete('pipeline/pipe_1234')
+    assert resp == ''


### PR DESCRIPTION
This PR fixes an issue where, if we received a 204 response from Close, we'd try to return `response.json()` and we'd receive a JSONDecodeError:
```
 json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
because 204 responses have no content to decode. 

This change makes it so that if we hit a 204, we just return an empty string. 