### PR TITLE
Fix rate limiting backoff behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-2.7
-      - test-3.5
-      - test-3.6
+      - test-3.7
+      - test-3.8
+      - test-3.9
+      - test-3.10
 
 defaults: &defaults
   working_directory: ~/code
@@ -14,21 +15,25 @@ defaults: &defaults
   - checkout
   - run:
       name: Install dependencies
-      command: sudo pip install -r requirements.txt
+      command: pip install -r requirements.txt
   - run:
       name: Test
       command: pytest
 
 jobs:
-  test-2.7:
+  test-3.7:
     <<: *defaults
     docker:
-    - image: circleci/python:2.7
-  test-3.5:
+    - image: cimg/python:3.7
+  test-3.8:
     <<: *defaults
     docker:
-    - image: circleci/python:3.5
-  test-3.6:
+    - image: cimg/python:3.8
+  test-3.9:
     <<: *defaults
     docker:
-    - image: circleci/python:3.6
+    - image: cimg/python:3.9
+  test-3.10:
+    <<: *defaults
+    docker:
+    - image: cimg/python:3.10

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -10,8 +10,8 @@ from closeio_api.utils import local_tz_offset
 DEFAULT_RATE_LIMIT_DELAY = 2   # Seconds
 
 # To update the package version, change this variable. This variable is also
-# read by setup.py when installing the package. 
-__version__ = '1.4'
+# read by setup.py when installing the package.
+__version__ = '2.0'
 
 class APIError(Exception):
     """Raised when sending a request to the API failed."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytest==3.0.7
 requests==2.21.0
-responses==0.5.1
+responses==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytest==3.0.7
-requests==2.21.0
+pytest==7.1.1
+requests==2.27.1
 responses==0.20.0

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     ],
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
     ]
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,16 +114,10 @@ def test_retry_on_rate_limit(api_client):
         rsps.add(
             responses.GET,
             'https://api.close.com/api/v1/lead/lead_abcdefghijklmnop/',
-            body=json.dumps({
-                "error": {
-                    "rate_reset": 1,
-                    "message": "API call count exceeded for this 15 second window",
-                    "rate_limit": 600,
-                    "rate_window": 15
-                }
-            }),
+            body=json.dumps({}),
             status=429,
-            content_type='application/json'
+            content_type='application/json',
+            headers={"Retry-After": "1", "RateLimit-Reset": "1"}
         )
 
         # Respond correctly to the second request.


### PR DESCRIPTION
This change:
* drops python 2 (so I can use `contextlib`)
* bumps the major version of the library
* adds testing on python versions 3.7-3.10
* updates the images to not use the deprecated `circleci/` images, instead preferring `cimg/`
* fixes rate limit backoff logic to read headers instead of the json body
* bumps the pinned `responses` version, so headers can be added to mocked responses
* bumps the pinned `requests` and `pytest` versions as well

Once this merges, a new release should be published to PyPi