### PR TITLE
Update client to respect the newer `RateLimit` header

### DIFF
--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import re
 import time
 
 from random import uniform
@@ -147,7 +148,19 @@ class API(object):
         status code is 429. 
         """
         with contextlib.suppress(KeyError):
+            rate_limit = response.headers["RateLimit"]
+            # we don't actually need all these values, but per the RFC:
+            # "Malformed RateLimit header fields MUST be ignored."
+            match = re.match(
+                r"limit=(\d+), remaining=(\d+), reset=(\d+)", rate_limit
+            )
+            if match:
+                limit, remaining, reset = match.groups()
+                return float(reset)
+
+        with contextlib.suppress(KeyError):
             return float(response.headers["Retry-After"])
+
         with contextlib.suppress(KeyError):
             return float(response.headers["RateLimit-Reset"])
 

--- a/closeio_api/__init__.py
+++ b/closeio_api/__init__.py
@@ -13,7 +13,7 @@ DEFAULT_RATE_LIMIT_DELAY = 2   # Seconds
 
 # To update the package version, change this variable. This variable is also
 # read by setup.py when installing the package.
-__version__ = '2.0'
+__version__ = '2.1'
 
 class APIError(Exception):
     """Raised when sending a request to the API failed."""


### PR DESCRIPTION
The client does currently respect rate limits, but the API has been updated to use the new `RateLimit` header to communicate those rate limits (instead of `RateLimit-Reset`).

Resolves https://github.com/closeio/closeio-api/issues/112

The library version is also bumped to `2.1` (and will need to be released after this is merged).