### PR TITLE
Add code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.reports
 
 #Translations
 *.mo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pytest==7.1.1
+pytest==7.4.0
+pytest-cov==4.1.0
 requests==2.27.1
 responses==0.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,13 @@
 [tool:pytest]
 testpaths=tests
+addopts = --cov closeio_api --cov-config=setup.cfg --cov-report=html --cov-report=xml --cov-report=term --junitxml=.reports/unit.xml
+
+[coverage:run]
+branch = True
+data_file = .reports/.coverage
+
+[coverage:html]
+directory = .reports/htmlcov
+
+[coverage:xml]
+output = .reports/coverage.xml


### PR DESCRIPTION
**Why**

In this PR I add code coverage reporting. I find it helpful to see code coverage results when writing tests and reviewing PRs. I thought this addition might be useful for the library.

**What**

* I added a new library, `pytest-cov`, which makes it easy to tie the standard coverage.py tool in with pytest.
* I took the opportunity to also bump the pytest library to the latest version.
* I added some configuration defaults to generate html, xml, and term reports.

**Testing**

1. ensure to pip install the new requirements
2. Run `pytest`
    * Tests should pass and show a terminal report of the code coverage for each file
    * There should be a `.reports` folder with the HTML version of the coverage report, as well as a xml version

```bash
---------- coverage: platform darwin, python 3.11.3-final-0 ----------
Name                      Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------
closeio_api/__init__.py     111     22     39      7    75%
closeio_api/utils.py          3      0      0      0   100%
-----------------------------------------------------------
TOTAL                       114     22     39      7    76%
Coverage HTML written to dir .reports/htmlcov
Coverage XML written to file .reports/coverage.xml
```