### PR TITLE
Add more tests around retry logic

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,9 @@ import json
 import pytest
 
 import responses
+import requests
 from closeio_api import APIError, Client
+from unittest import mock
 
 SAMPLE_LEAD_RESPONSE = {
     'name': 'Sample Lead',
@@ -148,6 +150,74 @@ def test_retry_on_rate_limit(api_client, headers):
         # Make sure two calls were made to the API (one rate limited and one
         # successful).
         assert len(rsps.calls) == 2
+
+
+@responses.activate
+def test_retry_on_connection_error(api_client):
+    with mock.patch('time.sleep'):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                body=requests.ConnectionError()
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                body=json.dumps(SAMPLE_LEADS_RESPONSE),
+                status=200,
+                content_type='application/json'
+            )
+
+            resp = api_client.get('lead')
+            assert resp['data'][0]['name'] == 'Sample Lead'
+            # Make sure two calls were made to the API (one connection error and one successful).
+            assert len(rsps.calls) == 2
+
+@responses.activate
+def test_max_retry_connection_error(api_client):
+    # retrying 5 times is a bit slow - skip the waiting
+    with mock.patch('time.sleep'):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                body=requests.ConnectionError()
+            )
+
+            with pytest.raises(requests.exceptions.ConnectionError):
+                api_client.get('lead')
+
+            # Make sure max calls were made
+            assert len(rsps.calls) == 5
+
+@responses.activate
+def test_raises_api_error_on_max_retry(api_client):
+    # retrying 5 times is a bit slow - skip the waiting
+    with mock.patch('time.sleep'):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                status=503,
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                status=502,
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.close.com/api/v1/lead/',
+                status=504,
+            )
+
+            with pytest.raises(APIError):
+                api_client.get('lead')
+
+            # Make sure max calls were made
+            assert len(rsps.calls) == 5
+
 
 @responses.activate
 def test_validation_error(api_client):


### PR DESCRIPTION
**Why**

I'm interested in this project and figured writing tests was a good opportunity to learn more about it. I saw code coverage was not at 100% - and so I focused on tests that would improve the coverage.

**What**

* Write a test for the retry logic on connection error, with eventual success
* Write a test for the retry logic on connection error - where max attempts are reached
* Write a test for the retry logic on 5XX errors - where max attempts are reached
* All of these tests are rather slow, so I mocked `time.sleep` to speed them up. Since that had good results, I tweaked the rate limiting test to also mock `time.sleep` - speeding up the tests.

**Testing**

* Run the tests - verify they are not really slow
* I used my other PR - https://github.com/closeio/closeio-api/pull/116 - to check the coverage of the new tests. These additional tests bump up the total coverage from 76% to 88%. There are opportunities for further improvement by removing some unreachable/dead code, but I didn't want to make any library changes.