### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
GitHub Actions runners switch their default Node runtime from Node 20 to
**Node 24 on June 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
This bumps the actions that were pinned to Node 20–era versions so CI keeps
working after the switch.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |

CI maintenance only — no application or runtime code changes.

Closes #127
